### PR TITLE
removed user id from logging

### DIFF
--- a/dist/services/recipe.service.js
+++ b/dist/services/recipe.service.js
@@ -23,12 +23,14 @@ class RecipeService {
     findRecipes(userId) {
         return __awaiter(this, void 0, void 0, function* () {
             try {
-                logger_1.logger.info('test logger');
+                logger_1.logger.info('Finding recipes for user: ' + userId);
                 const recipes = yield this.recipeRepository.findAllRecipes(userId);
                 const recipeListingDtos = recipes.map((recipe) => this.recipeMapper.recipeToRecipeListingDto(recipe));
+                logger_1.logger.info('Successfully found recipes');
                 return recipeListingDtos;
             }
             catch (e) {
+                logger_1.logger.error('Error finding recipes: ' + e);
                 throw e;
             }
         });
@@ -36,11 +38,14 @@ class RecipeService {
     getRecipeById(recipeId) {
         return __awaiter(this, void 0, void 0, function* () {
             try {
+                logger_1.logger.info('Getting details for recipe: ' + recipeId);
                 const recipe = yield this.recipeRepository.findRecipeById(recipeId);
                 const recipeDto = this.recipeMapper.recipeToRecipeDto(recipe);
+                logger_1.logger.info('Successfully found recipe details');
                 return recipeDto;
             }
             catch (e) {
+                logger_1.logger.error('Error getting recipe details: ' + e);
                 throw e;
             }
         });
@@ -48,6 +53,7 @@ class RecipeService {
     createRecipe(user) {
         return __awaiter(this, void 0, void 0, function* () {
             try {
+                logger_1.logger.info('Creating recipe for user: ' + user.id);
                 let recipe = {};
                 recipe.created_by = user.email;
                 recipe.user_id = user.id;
@@ -58,9 +64,11 @@ class RecipeService {
                 recipe.cook_time_minutes = 0;
                 recipe = yield this.recipeRepository.createRecipe(recipe);
                 const recipeDto = this.recipeMapper.recipeToRecipeDto(recipe);
+                logger_1.logger.info('Successfully created new recipe');
                 return recipeDto;
             }
             catch (e) {
+                logger_1.logger.error('Error creating recipe: ' + e);
                 throw e;
             }
         });
@@ -68,13 +76,16 @@ class RecipeService {
     updateRecipe(recipeId, recipe, user) {
         return __awaiter(this, void 0, void 0, function* () {
             try {
+                logger_1.logger.info('Editing recipe: ' + recipeId);
                 recipe.updated_by = user.email;
                 recipe.updated_ts = new Date();
                 recipe = yield this.recipeRepository.updateRecipe(recipeId, recipe);
                 const recipeDto = this.recipeMapper.recipeToRecipeDto(recipe);
+                logger_1.logger.info('Successfully updated recipe');
                 return recipeDto;
             }
             catch (e) {
+                logger_1.logger.error('Error updating recipe: ' + e);
                 throw e;
             }
         });
@@ -82,9 +93,12 @@ class RecipeService {
     deleteRecipe(recipeId) {
         return __awaiter(this, void 0, void 0, function* () {
             try {
+                logger_1.logger.info('Deleting recipe: ' + recipeId);
                 yield this.recipeRepository.deleteRecipe(recipeId);
+                logger_1.logger.info('Successfully deleted recipe');
             }
             catch (e) {
+                logger_1.logger.error('Error deleting recipe: ' + e);
                 throw e;
             }
         });

--- a/src/services/recipe.service.ts
+++ b/src/services/recipe.service.ts
@@ -11,10 +11,9 @@ export default class RecipeService {
 
     public async findRecipes(userId: string): Promise<RecipeListingDto[]> {
         try {
-            logger.info('Finding recipes for user: ' + userId);
+            // Note: Not adding info logs for this function so userId isn't exposed to console
             const recipes: Recipe[] = await this.recipeRepository.findAllRecipes(userId);
             const recipeListingDtos = recipes.map((recipe) => this.recipeMapper.recipeToRecipeListingDto(recipe))
-            logger.info('Successfully found recipes');
             return recipeListingDtos;
         } catch (e) {
             logger.error('Error finding recipes: ' + e);
@@ -27,7 +26,7 @@ export default class RecipeService {
             logger.info('Getting details for recipe: ' + recipeId);
             const recipe: Recipe = await this.recipeRepository.findRecipeById(recipeId);
             const recipeDto = this.recipeMapper.recipeToRecipeDto(recipe);
-            logger.info('Successfully found recipe details');
+            logger.info('Successfully found recipe details for recipe: ' + recipeId);
             return recipeDto;
         } catch (e) {
             logger.error('Error getting recipe details: ' + e);
@@ -37,7 +36,7 @@ export default class RecipeService {
 
     public async createRecipe(user: User): Promise<RecipeDto> {
         try {
-            logger.info('Creating recipe for user: ' + user.id);
+            // Note: Not adding info logs for this function so userId isn't exposed to console
             let recipe: Recipe = {} as Recipe;
             recipe.created_by = user.email;
             recipe.user_id = user.id;
@@ -49,7 +48,7 @@ export default class RecipeService {
 
             recipe = await this.recipeRepository.createRecipe(recipe);
             const recipeDto = this.recipeMapper.recipeToRecipeDto(recipe);
-            logger.info('Successfully created new recipe');
+            logger.info('Successfully updated recipe: ' + recipeDto.recipeId);
             return recipeDto;
         } catch (e) {
             logger.error('Error creating recipe: ' + e);
@@ -65,7 +64,7 @@ export default class RecipeService {
 
             recipe = await this.recipeRepository.updateRecipe(recipeId, recipe);
             const recipeDto = this.recipeMapper.recipeToRecipeDto(recipe);
-            logger.info('Successfully updated recipe');
+            logger.info('Successfully updated recipe: ' + recipeId);
             return recipeDto;
         } catch (e) {
             logger.error('Error updating recipe: ' + e);
@@ -77,7 +76,7 @@ export default class RecipeService {
         try {
             logger.info('Deleting recipe: ' + recipeId);
             await this.recipeRepository.deleteRecipe(recipeId);
-            logger.info('Successfully deleted recipe');
+            logger.info('Successfully deleted recipe: ' + recipeId);
         } catch (e) {
             logger.error('Error deleting recipe: ' + e);
             throw e;


### PR DESCRIPTION
In a previous PR, I added logging statements to all endpoints related to recipes with the winston npm package. In this PR, I:
- removed logging statements that showed the userId. Because most of the logs show the recipeId, I'll need to eventually create some authorization protocols to prevent users from interacting with recipes that aren't theirs.
- added recipeId descriptors to success logs